### PR TITLE
[cmyk-195] : 에고 검색시 하트/별점 보이도록 수정

### DIFF
--- a/lib/screens/ego_list_blurred_screen.dart
+++ b/lib/screens/ego_list_blurred_screen.dart
@@ -25,7 +25,7 @@ class _BlurredListScreenState extends State<BlurredListScreen> {
   String searchQuery = '';
   String selectedSort = '최신대화순';
 
-  final List<String> sortOptions = ['최신대화순', '이름순'];
+  final List<String> sortOptions = ['최신대화순', '이름순', '평점순', '하트 많은 순'];
 
   @override
   void initState() {
@@ -148,19 +148,15 @@ class _BlurredListScreenState extends State<BlurredListScreen> {
                 // 정렬 버튼
                 Padding(
                   padding: EdgeInsets.only(bottom: 8.h),
-                  child: Row(
-                    children: [
-                      SingleChildScrollView(
-                        scrollDirection: Axis.horizontal,
-                        padding: EdgeInsets.symmetric(horizontal: 16.w),
-                        child: Row(
-                          children:
-                              sortOptions
-                                  .map((option) => _buildSortButton(option))
-                                  .toList(),
-                        ),
-                      ),
-                    ],
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    padding: EdgeInsets.only(right: 16.h, left: 16.h, bottom: 5.h),
+                    child: Row(
+                      children:
+                          sortOptions
+                              .map((option) => _buildSortButton(option))
+                              .toList(),
+                    ),
                   ),
                 ),
 
@@ -188,10 +184,38 @@ class _BlurredListScreenState extends State<BlurredListScreen> {
                               fontWeight: FontWeight.w700,
                             ),
                           ),
-                          trailing: buildEgoListItem(
-                            ego.egoIcon,
-                            () {},
-                            radius: 19,
+                          trailing: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Row(
+                                children: [
+                                  Icon(
+                                    Icons.star,
+                                    color: Colors.amber,
+                                    size: 20,
+                                  ),
+                                  SizedBox(width: 4.w),
+                                  Text('4', style: TextStyle(fontSize: 14.sp)),
+                                ],
+                              ),
+                              SizedBox(width: 8.w),
+                              Row(
+                                children: [
+                                  Icon(
+                                    Icons.favorite,
+                                    color: AppColors.strongOrange,
+                                    size: 20,
+                                  ),
+                                  SizedBox(width: 4.w),
+                                  Text(
+                                    '123',
+                                    style: TextStyle(fontSize: 14.sp),
+                                  ),
+                                ],
+                              ),
+                              SizedBox(width: 10.w),
+                              buildEgoListItem(ego.egoIcon, () {}, radius: 19),
+                            ],
                           ),
                           onTap: () {
                             widget.onEgoSelected(ego);


### PR DESCRIPTION
### JIRA Task 🔖
**Ticket**: [CMYK-195](https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-195)
- **Branch** : feature/CMYK-195

### 작업 내용 📌
- EGO List 더보기 view 수정
  - List Item에 별 Icon과 하트 Icon 추가
- 필터 추가(로직은 작성되지 않음)
  - 하트 많은 순
  - 평점순

### 예시 화면 🖥
|실행화면|
|---|
|<img width="300" src="https://github.com/user-attachments/assets/9f997764-6c0f-4850-b2d7-ac0bb90398fc" />|

### 작업 배경 🔎 
- 사용자가 EGO의 하트수와 평점을 확인할 수 있음

### 참고 사항 📂


[CMYK-195]: https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-195