### PR TITLE
[CMYK-221] : 감정 캘린더 디자인 수정

### DIFF
--- a/lib/sample/cmyk-221/sample_emotion_diary_re.dart
+++ b/lib/sample/cmyk-221/sample_emotion_diary_re.dart
@@ -1,0 +1,92 @@
+import 'package:ego/sample/cmyk-46/tmp_screen.dart';
+import 'package:ego/screens/chat/chat_tab_screen.dart';
+import 'package:ego/screens/record/record_screen.dart';
+import 'package:ego/theme/theme.dart';
+import 'package:ego/widgets/appbar/main_app_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:intl/date_symbol_data_local.dart';
+
+import '../../screens/chat/ego_chat_room_list_screen.dart';
+
+/// AppBar 단위 테스트 코드
+/// SampleAppBarTest를 통해 위젯 비율을 조정하고 관리함
+void main() async {
+  await initializeDateFormatting();
+  runApp(
+    ProviderScope(
+      child: MainScreenTest(),
+    ),
+  );
+}
+
+class MainScreenTest extends StatelessWidget {
+  const MainScreenTest({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ScreenUtilInit(
+      designSize: Size(393, 852),
+      builder: (context, child) => MaterialApp(
+          title: '앱 바 테스트 페이지',
+          theme: AppTheme.lightTheme,
+          darkTheme: AppTheme.darkTheme,
+          initialRoute: 'Main',
+          routes: {
+            'Main': (context) => Consumer(
+              builder: (context, ref, child) {
+                return SampleMainScreen();
+              },
+            ),
+          }
+      ),
+    );
+  }
+}
+
+/// [MainAppBar]를 사용하기 위한 Screen 구성 예시
+///
+/// ConsumerStatefulWidget을 이용하여, TabBarController 상태를 지속적으로 관리한다.
+class SampleMainScreen extends ConsumerStatefulWidget {
+  @override
+  _SampleMainAppBarScreenState createState() => _SampleMainAppBarScreenState();
+}
+
+class _SampleMainAppBarScreenState extends ConsumerState<SampleMainScreen>
+    with SingleTickerProviderStateMixin {
+  /// 선택한 Tab과 Body를 매핑하는 Controller이다.
+  late TabController _tabController;
+
+  /// _tabCntroller 초기화
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this);
+  }
+
+  /// _tabCntroller 제거
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      /// 각 Screen으로 이동하기 위한 Navigator AppBar이다.
+      appBar: MainAppBar(_tabController),
+
+      /// MainAppBar에서 선택된 Tab의 Screen이 나타나는 영역이다.
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          TmpScreen(text: "스피크 페이지"), // TODO: 스피크 스크린에 연결
+          RecordScreen(), // 캘린더 페이지
+          ChatTabScreen()
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/diary/diary_container.dart
+++ b/lib/screens/diary/diary_container.dart
@@ -14,7 +14,8 @@ class DiaryContainer extends StatefulWidget {
   final Diary diary;
   final int containerId;
 
-  DiaryContainer({Key? key, required this.diary, required this.containerId}) : super(key: key);
+  DiaryContainer({Key? key, required this.diary, required this.containerId})
+    : super(key: key);
 
   @override
   _DiaryContainerState createState() => _DiaryContainerState();
@@ -160,6 +161,7 @@ class _DiaryContainerState extends State<DiaryContainer> {
 
           // 내용
           Container(
+            width: double.infinity,
             margin: EdgeInsets.only(bottom: 20.h),
             padding: EdgeInsets.only(bottom: 40.h),
             decoration: BoxDecoration(

--- a/lib/screens/diary/diary_edit_screen.dart
+++ b/lib/screens/diary/diary_edit_screen.dart
@@ -11,9 +11,9 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'diary_view_screen.dart';
 
 class DiaryEditScreen extends StatefulWidget {
-  final Diary diary;
+  final List<Diary> diaries;
 
-  const DiaryEditScreen({super.key, required this.diary});
+  const DiaryEditScreen({super.key, required this.diaries});
 
   @override
   State<DiaryEditScreen> createState() => _DiaryEditScreenState();
@@ -22,7 +22,7 @@ class DiaryEditScreen extends StatefulWidget {
 class _DiaryEditScreenState extends State<DiaryEditScreen> {
   @override
   Widget build(BuildContext context) {
-    final diary = widget.diary;
+    final diaries = widget.diaries;
 
     return Scaffold(
       appBar: StackAppBar(title: '일기수정'),
@@ -44,7 +44,7 @@ class _DiaryEditScreenState extends State<DiaryEditScreen> {
                       child: Padding(
                         padding: EdgeInsets.only(bottom: 8.h, top: 12.h),
                         child: Text(
-                          diary.date,
+                          diaries[0].date,
                           style: TextStyle(
                             fontSize: 16.sp,
                             color: AppColors.strongOrange,
@@ -53,11 +53,12 @@ class _DiaryEditScreenState extends State<DiaryEditScreen> {
                         ),
                       ),
                     ),
-
-                    _DiaryEditContainer(
-                      context,
-                      diary.title,
-                      diary.content,
+                    ...diaries.map(
+                          (diary) => _DiaryEditContainer(
+                        context,
+                        diary.title,
+                        diary.content,
+                      ),
                     ),
                   ],
                 ),
@@ -126,7 +127,7 @@ Widget _DiaryEditContainer(
         // 내용
         Container(
           margin: EdgeInsets.only(bottom: 12.h),
-          height: 150.h,
+          height: 96.h,
           child: RawScrollbar(
             thumbVisibility: true,
             thickness: 4.w,

--- a/lib/screens/diary/diary_view_for_bottom_sheet.dart
+++ b/lib/screens/diary/diary_view_for_bottom_sheet.dart
@@ -1,0 +1,226 @@
+import 'package:ego/screens/diary/share_all_diary.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'package:ego/models/ego_info_model.dart';
+import 'package:ego/screens/diary/diary_container.dart';
+import 'package:ego/screens/diary/diary_edit_screen.dart';
+import 'package:ego/widgets/appbar/stack_app_bar.dart';
+import 'package:ego/screens/diary/today_emotion_container.dart';
+import 'package:ego/theme/color.dart';
+import 'package:ego/widgets/customtoast/custom_toast.dart';
+import 'package:ego/widgets/button/svg_button.dart';
+
+import 'diary_view_screen.dart';
+import 'helped_ego_info_container.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+
+import 'one_sentence_review.dart';
+
+class DiaryViewForBottomSheet extends StatefulWidget {
+  final ScrollController scrollController;
+
+  const DiaryViewForBottomSheet({super.key, required this.scrollController});
+
+  @override
+  State<DiaryViewForBottomSheet> createState() =>
+      _DiaryViewForBottomSheetState();
+}
+
+class _DiaryViewForBottomSheetState extends State<DiaryViewForBottomSheet> {
+  final List<String> emotions = ['기쁨', '재미'];
+
+  final List<Diary> diaries = [
+    Diary(
+      date: '2025/02/28',
+      title: '친구랑 밥',
+      content:
+      '오늘은 친구랑 맛있는 음식을 먹으러 갔다. 오랜만에 만나서 그런지 더욱 맛있게 느껴졌고, 웃음꽃을 피우며 즐거운 시간을 보냈다. 음식도 맛있었고, 대화도 흥미로워서 시간 가는 줄 몰랐다. 너무 행복한 하루였다.',
+      image: 'assets/image/first_diary_sample_image.png',
+    ),
+    Diary(
+      date: '2025/02/28',
+      title: '친구랑 축구',
+      content:
+      '오늘 친구랑 축구를 하러 갔다. 날씨도 맑고 기분도 좋았다. 열심히 뛰고, 서로 패스하며 팀워크를 발휘했는데, 결국 멋진 골도 넣었다. 피곤했지만 즐겁고 시원한 하루였다. 같이 운동하니까 더 가까워진 느낌!',
+      image: 'assets/image/second_diary_sample_image.png',
+    ),
+  ];
+
+  final EgoInfoModel egoInfoModel = EgoInfoModel(
+    id: '1',
+    egoIcon: 'assets/image/ego_icon.png',
+    egoName: 'Power',
+    egoBirth: '2002/02/03',
+    egoPersonality: '단순함, 바보, 멍청',
+    egoSelfIntro: '크하하! 나는 최고로 귀엽고, 강하고, 멋진 피의 마녀, Power다!...',
+  );
+
+  late FToast fToast;
+
+  @override
+  void initState() {
+    super.initState();
+    fToast = FToast();
+    fToast.init(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(right: 2.w),
+      child: Container(
+        color: AppColors.white,
+        child: RawScrollbar(
+          thumbVisibility: true,
+          thickness: 4.w,
+          radius: Radius.circular(8.r),
+          thumbColor: AppColors.gray700,
+          child: SingleChildScrollView(
+            controller: widget.scrollController,
+            child: Column(
+              children: [
+                Center(
+                  child: Container(
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      color: AppColors.gray300,
+                      borderRadius: BorderRadius.all(Radius.circular(10.r)),
+                    ),
+                    margin: EdgeInsets.symmetric(vertical: 10.h),
+                    width: 40.w,
+                    height: 4.h,
+                  ),
+                ),
+
+                Container(
+                  padding: EdgeInsets.only(right: 20.w),
+                  color: AppColors.white,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      SvgButton(
+                        svgPath: 'assets/icon/share_icon.svg',
+                        width: 20.w,
+                        height: 20.h,
+                        radius: 16.r,
+                        onTab: () {
+                          // TODO 일기 공유시 템플렛 필요
+                          final customToast = CustomToast(
+                            toastMsg: '일기가 공유되었습니다.',
+                            iconPath: 'assets/icon/complete.svg',
+                            backgroundColor: AppColors.accent,
+                            fontColor: AppColors.white,
+                          );
+                          customToast.init(fToast);
+
+                          shareAllDiary('전체 공유', customToast);
+                        },
+                      ),
+                      SizedBox(width: 12.w),
+                      SvgButton(
+                        svgPath: 'assets/icon/edit_icon.svg',
+                        width: 20.w,
+                        height: 20.h,
+                        radius: 16.r,
+                        onTab: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder:
+                                  (context) =>
+                                      DiaryEditScreen(diaries: diaries),
+                            ),
+                          );
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+
+                // 감정 Container
+                TodayEmotionContainer(emotions),
+
+                // 날짜
+                Container(
+                  alignment: Alignment.centerLeft,
+                  child: Padding(
+                    padding: EdgeInsets.only(left:20.w,bottom: 8.h, top: 12.h),
+                    child: Text(
+                      diaries[0].date,
+                      style: TextStyle(
+                        fontSize: 16.sp,
+                        color: AppColors.gray600,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                ),
+
+                // 일기 정보 제공
+                ...diaries.asMap().map((index, diary) {
+                  return MapEntry(
+                    index,
+                    DiaryContainer(diary: diary, containerId: index),
+                  );
+                }).values,
+
+                // 일기 작성해준 EGO 정보
+                HelpedEgoInfoContainer(context, egoInfoModel),
+
+                SizedBox(height: 14.h),
+
+                // 오늘의 한 줄 요약
+                OneSentenceReview(
+                  "홍길동 에고와 가장 많이많이많이많이많이많이많이많이많이많이많이많이많이많이많이많이많이많이많이많이많이많이많이 대화하고, 의성어를 주로 사용해 배드민턴 이야기를 했어요.",
+                ),
+
+                // 일기 저장 버튼
+                Container(
+                  width: double.infinity,
+                  margin: EdgeInsets.only(bottom: 40.h,left: 20.w,right: 20.w),
+                  child: TextButton(
+                    onPressed: () {
+                      final customBottomToast = CustomToast(
+                        toastMsg: '일기가 저장되었습니다.',
+                        iconPath: 'assets/icon/complete.svg',
+                        backgroundColor: AppColors.accent,
+                        fontColor: AppColors.white,
+                      );
+                      customBottomToast.init(fToast);
+
+                      final position = 107.0.h;
+
+                      customBottomToast.showBottomPositionedToast(
+                        bottom: position,
+                      );
+                    },
+                    style: TextButton.styleFrom(
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8.r),
+                      ),
+                      padding: EdgeInsets.symmetric(
+                        horizontal: 20.w,
+                        vertical: 15.h,
+                      ),
+                      backgroundColor: AppColors.strongOrange,
+                    ),
+                    child: Text(
+                      "일기저장",
+                      style: TextStyle(
+                        color: AppColors.white,
+                        fontSize: 18.sp,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/diary/diary_view_for_bottom_sheet.dart
+++ b/lib/screens/diary/diary_view_for_bottom_sheet.dart
@@ -10,6 +10,7 @@ import 'package:ego/screens/diary/today_emotion_container.dart';
 import 'package:ego/theme/color.dart';
 import 'package:ego/widgets/customtoast/custom_toast.dart';
 import 'package:ego/widgets/button/svg_button.dart';
+import 'package:http/http.dart';
 
 import 'diary_view_screen.dart';
 import 'helped_ego_info_container.dart';
@@ -176,46 +177,7 @@ class _DiaryViewForBottomSheetState extends State<DiaryViewForBottomSheet> {
                   "홍길동 에고와 가장 많이많이많이많이많이많이많이많이많이많이많이많이많이많이많이많이많이많이많이많이많이많이많이 대화하고, 의성어를 주로 사용해 배드민턴 이야기를 했어요.",
                 ),
 
-                // 일기 저장 버튼
-                Container(
-                  width: double.infinity,
-                  margin: EdgeInsets.only(bottom: 40.h,left: 20.w,right: 20.w),
-                  child: TextButton(
-                    onPressed: () {
-                      final customBottomToast = CustomToast(
-                        toastMsg: '일기가 저장되었습니다.',
-                        iconPath: 'assets/icon/complete.svg',
-                        backgroundColor: AppColors.accent,
-                        fontColor: AppColors.white,
-                      );
-                      customBottomToast.init(fToast);
-
-                      final position = 107.0.h;
-
-                      customBottomToast.showBottomPositionedToast(
-                        bottom: position,
-                      );
-                    },
-                    style: TextButton.styleFrom(
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8.r),
-                      ),
-                      padding: EdgeInsets.symmetric(
-                        horizontal: 20.w,
-                        vertical: 15.h,
-                      ),
-                      backgroundColor: AppColors.strongOrange,
-                    ),
-                    child: Text(
-                      "일기저장",
-                      style: TextStyle(
-                        color: AppColors.white,
-                        fontSize: 18.sp,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                  ),
-                ),
+                SizedBox(height : 35.h)
               ],
             ),
           ),

--- a/lib/screens/diary/diary_view_screen.dart
+++ b/lib/screens/diary/diary_view_screen.dart
@@ -42,14 +42,23 @@ class _DiaryViewScreenState extends State<DiaryViewScreen> {
   // 임시 감정
   final List<String> emotions = ['기쁨', '재미'];
 
-  // 임시 주제 일기 (하나만 받도록 수정)
-  final Diary diary = Diary(
-    date: '2025/02/28',
-    title: '친구랑 밥',
-    content:
-        '오늘은 친구랑 맛있는 음식을 먹으러 갔다. 오랜만에 만나서 그런지 더욱 맛있게 느껴졌고, 웃음꽃을 피우며 즐거운 시간을 보냈다. 음식도 맛있었고, 대화도 흥미로워서 시간 가는 줄 몰랐다. 너무 행복한 하루였다.',
-    image: 'assets/image/first_diary_sample_image.png',
-  );
+  // 임시 주제 일기
+  final List<Diary> diaries = [
+    Diary(
+      date: '2025/02/28',
+      title: '친구랑 밥',
+      content:
+          '오늘은 친구랑 맛있는 음식을 먹으러 갔다. 오랜만에 만나서 그런지 더욱 맛있게 느껴졌고, 웃음꽃을 피우며 즐거운 시간을 보냈다. 음식도 맛있었고, 대화도 흥미로워서 시간 가는 줄 몰랐다. 너무 행복한 하루였다.',
+      image: 'assets/image/first_diary_sample_image.png',
+    ),
+    Diary(
+      date: '2025/02/28',
+      title: '친구랑 축구',
+      content:
+          '오늘 친구랑 축구를 하러 갔다. 날씨도 맑고 기분도 좋았다. 열심히 뛰고, 서로 패스하며 팀워크를 발휘했는데, 결국 멋진 골도 넣었다. 피곤했지만 즐겁고 시원한 하루였다. 같이 운동하니까 더 가까워진 느낌!',
+      image: 'assets/image/second_diary_sample_image.png',
+    ),
+  ];
 
   // 임시 EGO 정보
   final EgoInfoModel egoInfoModel = EgoInfoModel(
@@ -87,8 +96,8 @@ class _DiaryViewScreenState extends State<DiaryViewScreen> {
             child: SingleChildScrollView(
               child: Column(
                 children: [
-                  // edit(전체수정), share(전체공유) 버튼
                   Container(
+                    margin: EdgeInsets.only(right: 20.w),
                     color: AppColors.white,
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.end,
@@ -122,7 +131,8 @@ class _DiaryViewScreenState extends State<DiaryViewScreen> {
                               context,
                               MaterialPageRoute(
                                 builder:
-                                    (context) => DiaryEditScreen(diary: diary),
+                                    (context) =>
+                                        DiaryEditScreen(diaries: diaries),
                               ),
                             );
                           },
@@ -131,12 +141,11 @@ class _DiaryViewScreenState extends State<DiaryViewScreen> {
                     ),
                   ),
 
-                  // 감정 Container
+                  //감정 Container
                   TodayEmotionContainer(emotions),
 
                   // 날짜
                   Container(
-                    color: AppColors.white,
                     alignment: Alignment.centerLeft,
                     child: Padding(
                       padding: EdgeInsets.only(
@@ -146,7 +155,7 @@ class _DiaryViewScreenState extends State<DiaryViewScreen> {
                         right: 20.w,
                       ),
                       child: Text(
-                        diary.date,
+                        diaries[0].date,
                         style: TextStyle(
                           fontSize: 16.sp,
                           color: AppColors.gray600,
@@ -157,7 +166,12 @@ class _DiaryViewScreenState extends State<DiaryViewScreen> {
                   ),
 
                   // 일기 정보 제공
-                  DiaryContainer(diary: diary, containerId: 0),
+                  ...diaries.asMap().map((index, diary) {
+                    return MapEntry(
+                      index,
+                      DiaryContainer(diary: diary, containerId: index),
+                    );
+                  }).values,
 
                   // 일기 작성해준 EGO 정보
                   HelpedEgoInfoContainer(context, egoInfoModel),
@@ -172,8 +186,7 @@ class _DiaryViewScreenState extends State<DiaryViewScreen> {
                   // 일기 저장 버튼
                   Container(
                     width: double.infinity,
-                    color: AppColors.white,
-                    padding: EdgeInsets.only(
+                    margin: EdgeInsets.only(
                       bottom: 40.h,
                       left: 20.w,
                       right: 20.w,

--- a/lib/screens/diary/one_sentence_review.dart
+++ b/lib/screens/diary/one_sentence_review.dart
@@ -5,42 +5,40 @@ import 'package:ego/theme/color.dart';
 // 오늘의 한 줄 요약 내용 부분
 Widget OneSentenceReview(String sentence) {
   return Container(
-    child: Container(
-      padding: EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: AppColors.white,
-        borderRadius: BorderRadius.only(
-          topLeft: Radius.circular(20.r),
-          topRight: Radius.circular(20.r),
-        ),
+    padding: EdgeInsets.all(20),
+    decoration: BoxDecoration(
+      color: AppColors.white,
+      borderRadius: BorderRadius.only(
+        topLeft: Radius.circular(20.r),
+        topRight: Radius.circular(20.r),
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            "오늘의 한 줄 요약",
-            style: TextStyle(
-              color: AppColors.black,
-              fontWeight: FontWeight.w700,
-              fontSize: 18.sp,
-            ),
+    ),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          "오늘의 한 줄 요약",
+          style: TextStyle(
+            color: AppColors.black,
+            fontWeight: FontWeight.w700,
+            fontSize: 18.sp,
           ),
-          SizedBox(height: 10.h),
-          Container(
-            height: 100.h,
-            child: SingleChildScrollView(
-              child: Text(
-                '"$sentence"',
-                style: TextStyle(
-                  color: AppColors.black,
-                  fontWeight: FontWeight.w500,
-                  fontSize: 18.sp,
-                ),
+        ),
+        SizedBox(height: 10.h),
+        Container(
+          height: 100.h,
+          child: SingleChildScrollView(
+            child: Text(
+              '"$sentence"',
+              style: TextStyle(
+                color: AppColors.black,
+                fontWeight: FontWeight.w500,
+                fontSize: 18.sp,
               ),
             ),
           ),
-        ],
-      ),
+        ),
+      ],
     ),
   );
 }

--- a/lib/screens/record/calendar/calendar_screen.dart
+++ b/lib/screens/record/calendar/calendar_screen.dart
@@ -2,15 +2,25 @@ import 'package:ego/widgets/bottomsheet/calendar_bottom_sheet.dart';
 import 'package:ego/widgets/diarycalendar/diary_calendar.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class CalendarScreen extends StatelessWidget {
-  const CalendarScreen({super.key});
+class CalendarScreen extends ConsumerWidget {
+  CalendarScreen({super.key});
+
+  // 날짜 감지 TODO 날짜를 전달 받는 것이 아니라 일별 Diday객체를 감지할 것임 + 거기서 diaryid로 ValendarBottomSheet에서 일기 원본 조회
+  final selectedDateProvider = StateProvider<DateTime?>((ref) => null);
+
+  void _onClickDate(WidgetRef ref, DateTime date) {
+    ref.read(selectedDateProvider.notifier).state = date;
+  }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Stack(
       children: [
-        DiaryCalendar(),
+        DiaryCalendar(
+          onClickDate: (date) => _onClickDate(ref, date),
+        ),
         CalendarBottomSheet(),
       ],
     );

--- a/lib/widgets/bottomsheet/calendar_bottom_sheet.dart
+++ b/lib/widgets/bottomsheet/calendar_bottom_sheet.dart
@@ -1,3 +1,5 @@
+import 'package:ego/screens/diary/diary_view_for_bottom_sheet.dart';
+import 'package:ego/screens/diary/diary_view_screen.dart';
 import 'package:ego/theme/color.dart';
 import 'package:ego/utils/constants.dart';
 import 'package:ego/widgets/diarycard/diary_card.dart';
@@ -25,37 +27,7 @@ class _CalendarBottomSheetState extends State<CalendarBottomSheet> {
       maxChildSize: 1.0, // 최대 값 설정 (부모 컴포넌트 기준 비율)
       /// BottomSheet에 나타날 컴포넌트
       builder: (BuildContext context, ScrollController scrollController) {
-        return Container(
-          decoration: BoxDecoration( // BottomSheet의 형태를 디자인한다.
-            color: AppColors.gray100, // 배경 색
-            borderRadius: BorderRadius.only(
-              topRight: Radius.circular(12.r), // 상단 우측 모서리 굴곡
-              topLeft: Radius.circular(12.r), // 상단 좌측 모서리 굴곡
-            ),
-            /// BottomSheet에 그림자 지정
-            boxShadow: [
-              BoxShadow(
-                // 255 * 8% = 20.4 (피그마에서 black의 투명도 8%로 설정)
-                color: AppColors.black.withAlpha(21),
-                blurRadius: 10.r,
-                spreadRadius: 4.r,
-                offset: Offset(0, 4.h),
-              )
-            ],
-          ),
-          // 일기 카드의 너비를 지정하기 위한 패딩이다.
-          padding: EdgeInsets.symmetric(horizontal: 20.w),
-
-          /// 바텀시트 실질적인 body
-          child: CustomScrollView(
-            // 스크롤을 관리하는 컨트롤러 주입(scrollController는 DraggableScrollableSheet.builder의 매개 변수이다.)
-            controller: scrollController,
-            slivers: [
-              _sliverToBoxAdapter(), // 바텀 시트 크기를 조정할 수 있는 handler 컴포넌트
-              _sliverList(), // 일기 카드가 나타나는 ListView 컴포넌트
-            ],
-          ),
-        );
+        return DiaryViewForBottomSheet(scrollController: scrollController);
       }
     );
   }
@@ -78,24 +50,6 @@ class _CalendarBottomSheetState extends State<CalendarBottomSheet> {
           height: 4.h, // 컨테이너(handler) 높이 지정
         ),
       )
-    );
-  }
-
-  /// 일기 카드 리스트가 나타날 ListView 컴포넌트
-  ///
-  /// TODO: 현재는 샘플 리스트를 index로 구분한다.
-  SliverList _sliverList() {
-    return SliverList(
-      delegate: SliverChildBuilderDelegate(
-              (context, index) {
-            return DiaryCard( // TODO: DiaryCard 샘플
-              date: DateTime.now(),
-              emotions: const [Emotion.happiness],
-              egoName: 'Ego 이름: $index',
-              story: '요약된 일기 내용을 보여줍니다.이날은 무슨일이 있었고, 어쩌고 저쩌고. 이러쿵 저러쿵. 이야기를 작성하게 됩니다. 마지막은 점점점',
-            );
-          }
-      ),
     );
   }
 }

--- a/lib/widgets/diarycalendar/diary_calendar.dart
+++ b/lib/widgets/diarycalendar/diary_calendar.dart
@@ -11,13 +11,18 @@ import 'package:table_calendar/table_calendar.dart';
 /// TODO: 현재는 다른 화면으로 이동하고 돌아오면 초기화 된다. (퍼블이므로 수정하진 않음)
 /// TODO: 다른 달인데, 감정 아이콘이 있는 경우 (색상이 옅어져야 함.)
 class DiaryCalendar extends StatefulWidget {
+  final void Function(DateTime) onClickDate;
+
+  const DiaryCalendar({super.key, required this.onClickDate});
+
   @override
-  State<StatefulWidget> createState() => _DiaryCalendarState();
+  State<DiaryCalendar> createState() => _DiaryCalendarState();
 }
 
 class _DiaryCalendarState extends State<DiaryCalendar> {
   /// [_focusedDay] 화면에 띄워지는 날짜. 기본적으로 DateTime.now()이다.
-  DateTime _focusedDay = DateTime.now(); // 현재 달
+  DateTime _focusedDay = DateTime.now(); // 현재
+  DateTime? _selectedDay;
 
   /// [_emotions] 사용자가 일기를 작성한 날짜와 당시의 감정(대표 감정 1개)을 담은 Map 컨테이너
   final Map<DateTime, Emotion> _emotions = {
@@ -31,36 +36,51 @@ class _DiaryCalendarState extends State<DiaryCalendar> {
 
   @override
   Widget build(BuildContext context) {
-    return Padding( // 캘린더 Padding 지정
+    return Padding(
+      // 캘린더 Padding 지정
       padding: EdgeInsets.symmetric(vertical: 12.h, horizontal: 20.w),
       child: TableCalendar(
         /// 기본 캘린더 속성 정보들
-        locale: 'ko_KR', // 한국어 타입으로 변경, 기념일 등 정보를 전달하는 것으로 추정
-        firstDay: DateTime(2000, 1, 1), // 캘린더 시작 날짜, 2000-01-01, 변경 가능하다.
-        lastDay: DateTime(DateTime.now().year, DateTime.now().month, 42), // 이번 달이 일요일인 기준 6주 (7*6=42)
-        focusedDay: _focusedDay, // 조회할 날짜(객체) 고정
-        pageAnimationEnabled: false, // 페이지 애니메이션 제거. 어차피 현재 날짜 고정이라 없어도 됨
+        locale: 'ko_KR',
+        // 한국어 타입으로 변경, 기념일 등 정보를 전달하는 것으로 추정
+        firstDay: DateTime(2000, 1, 1),
+        // 캘린더 시작 날짜, 2000-01-01, 변경 가능하다.
+        lastDay: DateTime(DateTime.now().year, DateTime.now().month, 42),
+        // 이번 달이 일요일인 기준 6주 (7*6=42)
+        focusedDay: _focusedDay,
+        // 조회할 날짜(객체) 고정
+        pageAnimationEnabled: false,
+        // 페이지 애니메이션 제거. 어차피 현재 날짜 고정이라 없어도 됨
 
         /// 캘린더의 상단부 정보들
-        headerStyle: _headerStyle(), // 캘린더의 날짜(월)을 조정하는 영역
+        headerStyle: _headerStyle(),
+        // 캘린더의 날짜(월)을 조정하는 영역
 
         /// 캘린더 요일 부분 정보들
         ///
         /// `daysOfWeekHeight`에 + 8.h가 추가되는 이유는 `_headerStyle()` 주석 참고
-        daysOfWeekStyle: _daysOfWeekStyle(), // 캘린더의 요일이 나타나는 영역
-        daysOfWeekHeight: 20.h + 8.h, // 캘린더의 요일이 나타나는 영역 높이
+        daysOfWeekStyle: _daysOfWeekStyle(),
+        // 캘린더의 요일이 나타나는 영역
+        daysOfWeekHeight: 20.h + 8.h,
+        // 캘린더의 요일이 나타나는 영역 높이
 
         /// 캘린더 핵심부 정보들
-        calendarStyle: _calendarStyle(), // 날짜를 보여주는 영역
-        calendarBuilders: _calendarBuilders(), // 캘린더의 동적 정보를 명시하는 영역
-        rowHeight: 60.h, // 날짜를 보여주는 영역 높이
-        sixWeekMonthsEnforced: true, // 6주 보기
+        calendarStyle: _calendarStyle(),
+        // 날짜를 보여주는 영역
+        calendarBuilders: _calendarBuilders(),
+        // 캘린더의 동적 정보를 명시하는 영역
+        rowHeight: 60.h,
+        // 날짜를 보여주는 영역 높이
+        sixWeekMonthsEnforced: true,
+        // 6주 보기
 
         /// 상단부 조작 관련 정보
-        onPageChanged: (focusedDay) { // 사용자가 다음 달로 이동하는 것을 방지하는 내용
+        onPageChanged: (focusedDay) {
+          // 사용자가 다음 달로 이동하는 것을 방지하는 내용
           DateTime now = DateTime.now();
           // 다음 달로 넘어갔을 때,
-          if (focusedDay.year > now.year || (focusedDay.year == now.year && focusedDay.month > now.month)) {
+          if (focusedDay.year > now.year ||
+              (focusedDay.year == now.year && focusedDay.month > now.month)) {
             setState(() {
               _focusedDay = now; // 다시 현재 달로 고정
             });
@@ -73,6 +93,16 @@ class _DiaryCalendarState extends State<DiaryCalendar> {
 
         /// 캘린더 마커(사용자 일기 감정)를 표시하는 영역
         eventLoader: (day) => _loadEvents(day),
+
+        selectedDayPredicate: (day) => isSameDay(day, _selectedDay),
+
+        onDaySelected: (selectedDay, focusedDay) {
+          setState(() {
+            _selectedDay = selectedDay;
+          });
+
+          widget.onClickDate(selectedDay);
+        },
       ),
     );
   }
@@ -100,8 +130,10 @@ class _DiaryCalendarState extends State<DiaryCalendar> {
   /// 추후 해당 부분이 업데이트 된다면 수정할 것.
   HeaderStyle _headerStyle() {
     return HeaderStyle(
-      formatButtonVisible: false, // 캘린더 날짜 단위 변경 버튼 제거
-      titleCentered: true, // 현재 월을 캘린더 중심에 배치한다.
+      formatButtonVisible: false,
+      // 캘린더 날짜 단위 변경 버튼 제거
+      titleCentered: true,
+      // 현재 월을 캘린더 중심에 배치한다.
       titleTextStyle: TextStyle(
         color: AppColors.black,
         fontSize: 18.sp,
@@ -147,10 +179,7 @@ class _DiaryCalendarState extends State<DiaryCalendar> {
   ///
   /// 두 매개 변수의 속성 값은 동일하다.
   DaysOfWeekStyle _daysOfWeekStyle() {
-    return DaysOfWeekStyle(
-      weekdayStyle: _daysOfWeekTextStyle(),
-      weekendStyle: _daysOfWeekTextStyle()
-    );
+    return DaysOfWeekStyle(weekdayStyle: _daysOfWeekTextStyle());
   }
 
   /// 캘린더 핵심부 정보들
@@ -160,8 +189,10 @@ class _DiaryCalendarState extends State<DiaryCalendar> {
   /// 이외의 모든 매개 변수의 속성 값은 동일하다.
   CalendarStyle _calendarStyle() {
     return CalendarStyle(
-      cellAlignment: Alignment.topCenter, // 날짜 배치 위치
-      cellMargin: EdgeInsets.zero, // 날짜 칸의 영역
+      cellAlignment: Alignment.topCenter,
+      // 날짜 배치 위치
+      cellMargin: EdgeInsets.zero,
+      // 날짜 칸의 영역
       // 날짜 칸의 세부 영역(날짜 텍스트 배치 위치)
       cellPadding: EdgeInsets.symmetric(vertical: 8.h, horizontal: 3.w),
 
@@ -170,6 +201,14 @@ class _DiaryCalendarState extends State<DiaryCalendar> {
 
       // 당일 날짜 칸은 회색 BoxColor를 이용한다.
       todayDecoration: _todayDecoration(),
+
+      // 선택된 날짜 스타일
+      selectedDecoration: BoxDecoration(
+        color: AppColors.primary, // 선택된 날짜 배경색
+      ),
+      selectedTextStyle: TextStyle(
+        color: Colors.white, // 선택된 날짜 글자색
+      ),
     );
   }
 
@@ -179,32 +218,49 @@ class _DiaryCalendarState extends State<DiaryCalendar> {
       /// 감정 이모티콘을 동적으로 디자인한다.
       /// `events`는 감정 아이콘의 경로이다.
       markerBuilder: (_, date, events) {
-        return Padding( // 날짜 텍스트와의 간격을 위함
+        return Padding(
+          // 날짜 텍스트와의 간격을 위함
           padding: EdgeInsets.symmetric(vertical: 8.h),
-          child: ClipOval( // 원형 이미지를 위함
-            child: SizedBox( // 이모티콘이 나타나는 공간
+          child: ClipOval(
+            // 원형 이미지를 위함
+            child: SizedBox(
+              // 이모티콘이 나타나는 공간
               width: 24.w,
               height: 24.h,
-              child: events.isNotEmpty // 해당 날짜에 일기를 작성했는지 여부(Emotion 유무)
-                ? SvgPicture.asset(events[0]) // 존재한다면, Emotion의 아이콘을 가져온다.
-                : date.month == _focusedDay.month // 존재하지 않는다면, 당일과 해당 날짜를 비교하여
-                  ? ColoredBox(color: AppColors.gray200) // 당일 날짜 이전이면, 짙은 회색
-                  : ColoredBox(color: AppColors.gray200.withAlpha(127)), // 당일 날짜 이후이면, 옅은 회색 (일기 존재할 수 없음)
+              child:
+                  events
+                          .isNotEmpty // 해당 날짜에 일기를 작성했는지 여부(Emotion 유무)
+                      ? SvgPicture.asset(
+                        events[0],
+                      ) // 존재한다면, Emotion의 아이콘을 가져온다.
+                      : date.month ==
+                          _focusedDay
+                              .month // 존재하지 않는다면, 당일과 해당 날짜를 비교하여
+                      ? ColoredBox(
+                        color: AppColors.gray200,
+                      ) // 당일 날짜 이전이면, 짙은 회색
+                      : ColoredBox(
+                        color: AppColors.gray200.withAlpha(127),
+                      ), // 당일 날짜 이후이면, 옅은 회색 (일기 존재할 수 없음)
             ),
           ),
         );
       },
+
       /// 캘린더 요일 부분에서 일요일의 색상을 동적으로 변경한다.
       dowBuilder: (_, date) {
-        return date.weekday == DateTime.sunday // 일요일만 선택
-        ? Center(
-          child: Text(
-            '일',
-            style: _daysOfWeekTextStyle()
-                .copyWith(color: AppColors.red)
-          ),
-        ) : null; // 다른 요일은 `_daysOfWeekStyle()` 참고
+        return date.weekday ==
+                DateTime
+                    .sunday // 일요일만 선택
+            ? Center(
+              child: Text(
+                '일',
+                style: _daysOfWeekTextStyle().copyWith(color: AppColors.red),
+              ),
+            )
+            : null; // 다른 요일은 `_daysOfWeekStyle()` 참고
       },
+
       /// 평일 날짜 칸을 동적으로 디자인한다.
       defaultBuilder: (_, date, _) {
         return Container(
@@ -214,14 +270,19 @@ class _DiaryCalendarState extends State<DiaryCalendar> {
           child: Text(
             date.day.toString(), // 해당 날짜
             style: _defaultTextStyle() // 텍스트 서식
-              .copyWith(
-                color: date.weekday == DateTime.sunday // 일요일인 경우에
-                  ? AppColors.red // 일요일이라면, 빨간색
-                  : null // 아니라면, 기존 색상 사용
-              ),
+                .copyWith(
+                  color:
+                      date.weekday ==
+                              DateTime
+                                  .sunday // 일요일인 경우에
+                          ? AppColors
+                              .red // 일요일이라면, 빨간색
+                          : null, // 아니라면, 기존 색상 사용
+                ),
           ),
         );
       },
+
       /// 해당 달이 아닌 날짜 칸을 동적으로 디자인한다.
       outsideBuilder: (_, date, _) {
         return Container(
@@ -232,13 +293,19 @@ class _DiaryCalendarState extends State<DiaryCalendar> {
             date.day.toString(), // 해당 날짜
             style: _defaultTextStyle() // 텍스트 서식
                 .copyWith(
-                color: date.weekday == DateTime.sunday
-                    ? AppColors.red.withAlpha(127) // default 색상에서 투명도 50% 부여
-                    : AppColors.gray700.withAlpha(127) // default 색상들에서 투명도 50% 부여
-            ),
+                  color:
+                      date.weekday == DateTime.sunday
+                          ? AppColors.red.withAlpha(
+                            127,
+                          ) // default 색상에서 투명도 50% 부여
+                          : AppColors.gray700.withAlpha(
+                            127,
+                          ), // default 색상들에서 투명도 50% 부여
+                ),
           ),
         );
       },
+
       /// 공휴일인 날짜 칸을 동적으로 디자인한다.
       holidayBuilder: (_, date, _) {
         return Container(
@@ -248,18 +315,17 @@ class _DiaryCalendarState extends State<DiaryCalendar> {
           child: Text(
             date.day.toString(), // 해당 날짜
             style: _defaultTextStyle() // 텍스트 서식
-              .copyWith(
-              color: AppColors.red
-            ),
+                .copyWith(color: AppColors.red),
           ),
         );
-      }
+      },
     );
   }
 
   /// 평일의 날짜 글자 속성을 지정하는 함수이다.
   TextStyle _defaultTextStyle() {
-    return TextStyle( // 평일 텍스트 스타일
+    return TextStyle(
+      // 평일 텍스트 스타일
       color: AppColors.black, // 검정색
       fontSize: 14.sp,
       fontWeight: FontWeight.w400,
@@ -268,7 +334,8 @@ class _DiaryCalendarState extends State<DiaryCalendar> {
 
   /// 캘린더 요일 영역의 서식을 지정하는 함수이다.
   TextStyle _daysOfWeekTextStyle() {
-    return TextStyle( // 주말 관련
+    return TextStyle(
+      // 주말 관련
       color: AppColors.gray400,
       fontSize: 14.sp,
       fontWeight: FontWeight.w500,


### PR DESCRIPTION
### JIRA Task 🔖
**Ticket**: [CMYK-221](https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-221)
**Ticket**: [CMYK-209](https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-209)
- **Branch** : feature/CMYK-221

### 작업 내용 📌
- 캘린더 화면의 BottomSheet부분을 일기 화면으로 바뀌도록 수정
- DiaryScreen에서 List<Diary>를 전달받도록 수정했습니다.

### 예시 화면 🖥
|실행화면|
|---|
|<img width="300" src="https://github.com/user-attachments/assets/40db6992-15dd-40fe-b6ff-4f641e48175b" />|

### 작업 배경 🔎 
- 사용자는 달력에서 클릭한 일자의 일기를 확인, 수정할 수 있습니다.

### 참고 사항 📂

[CMYK-221]: https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-221

[CMYK-209]: https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ