### PR TITLE
[CMYK-223] : 감정 캘린더

### DIFF
--- a/lib/models/diary/diary.dart
+++ b/lib/models/diary/diary.dart
@@ -1,0 +1,41 @@
+class Diary {
+  final int diaryId;
+  final String uid;
+  final int egoId;
+  final String? feeling;
+  final String? dailyComment;
+  final DateTime createdAt;
+
+  Diary({
+    required this.diaryId,
+    required this.uid,
+    required this.egoId,
+    this.feeling,
+    this.dailyComment,
+    required this.createdAt,
+  });
+
+  // JSON → Diary (fromJson)
+  factory Diary.fromJson(Map<String, dynamic> json) {
+    return Diary(
+      diaryId: json['diaryId'],
+      uid: json['uid'],
+      egoId: json['egoId'],
+      feeling: json['feeling'],
+      dailyComment: json['dailyComment'],
+      createdAt: DateTime.parse(json['createdAt']),
+    );
+  }
+
+  // Diary → JSON (toJson)
+  Map<String, dynamic> toJson() {
+    return {
+      'diaryId': diaryId,
+      'uid': uid,
+      'egoId': egoId,
+      'feeling': feeling,
+      'dailyComment': dailyComment,
+      'createdAt': createdAt.toIso8601String(),
+    };
+  }
+}

--- a/lib/models/diary/diary.dart
+++ b/lib/models/diary/diary.dart
@@ -2,20 +2,23 @@ class Diary {
   final int diaryId;
   final String uid;
   final int egoId;
-  final String? feeling;
-  final String? dailyComment;
-  final DateTime createdAt;
+  final String feeling;
+  final String dailyComment;
+  final String createdAt;
+  final List<String> keywords; // String으로 수정 필요
+  final List<Topic> topics;
 
   Diary({
     required this.diaryId,
     required this.uid,
     required this.egoId,
-    this.feeling,
-    this.dailyComment,
+    required this.feeling,
+    required this.dailyComment,
     required this.createdAt,
+    required this.keywords,
+    required this.topics,
   });
 
-  // JSON → Diary (fromJson)
   factory Diary.fromJson(Map<String, dynamic> json) {
     return Diary(
       diaryId: json['diaryId'],
@@ -23,11 +26,14 @@ class Diary {
       egoId: json['egoId'],
       feeling: json['feeling'],
       dailyComment: json['dailyComment'],
-      createdAt: DateTime.parse(json['createdAt']),
+      createdAt: json['createdAt'],
+      keywords: List<String>.from(json['keywords']),
+      topics: (json['topics'] as List)
+          .map((topicJson) => Topic.fromJson(topicJson))
+          .toList(),
     );
   }
 
-  // Diary → JSON (toJson)
   Map<String, dynamic> toJson() {
     return {
       'diaryId': diaryId,
@@ -35,7 +41,49 @@ class Diary {
       'egoId': egoId,
       'feeling': feeling,
       'dailyComment': dailyComment,
-      'createdAt': createdAt.toIso8601String(),
+      'createdAt': createdAt,
+      'keywords': keywords,
+      'topics': topics.map((t) => t.toJson()).toList(),
+    };
+  }
+}
+
+class Topic {
+  final int topicId;
+  final int diaryId;
+  final String title;
+  final String content;
+  final String url;
+  final bool isDeleted;
+
+  Topic({
+    required this.topicId,
+    required this.diaryId,
+    required this.title,
+    required this.content,
+    required this.url,
+    required this.isDeleted,
+  });
+
+  factory Topic.fromJson(Map<String, dynamic> json) {
+    return Topic(
+      topicId: json['topicId'],
+      diaryId: json['diaryId'],
+      title: json['title'],
+      content: json['content'],
+      url: json['url'],
+      isDeleted: json['isDeleted'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'topicId': topicId,
+      'diaryId': diaryId,
+      'title': title,
+      'content': content,
+      'url': url,
+      'isDeleted': isDeleted,
     };
   }
 }

--- a/lib/models/diary/monthly_diary.dart
+++ b/lib/models/diary/monthly_diary.dart
@@ -1,0 +1,20 @@
+class MonthlyDiary {
+  final int id;
+  final DateTime createdAt;
+  final String path;
+
+  MonthlyDiary({
+    required this.id,
+    required this.createdAt,
+    required this.path
+  });
+
+  // JSON → Diary (fromJson)
+  factory MonthlyDiary.fromJson(Map<String, dynamic> json) {
+    return MonthlyDiary(
+      id: json['id'],
+      createdAt: DateTime.parse(json['createdAt']),
+      path: json['path']
+    );
+  }
+}

--- a/lib/providers/diary/monthly_diary_provider.dart
+++ b/lib/providers/diary/monthly_diary_provider.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:ego/models/diary/monthly_diary.dart';
+import 'package:ego/services/diary/monthly_diary_service.dart';
+
+final monthlyDiaryProvider = FutureProvider.family.autoDispose<List<MonthlyDiary>, ({String userId, int year, int month})>((ref, params) async {
+  return await MonthlyDiaryService.fetchMonthlyDiaries(
+    userId: params.userId,
+    year: params.year,
+    month: params.month,
+  );
+});

--- a/lib/screens/diary/diary_view_for_bottom_sheet.dart
+++ b/lib/screens/diary/diary_view_for_bottom_sheet.dart
@@ -21,8 +21,9 @@ import 'one_sentence_review.dart';
 
 class DiaryViewForBottomSheet extends StatefulWidget {
   final ScrollController scrollController;
+  final int diaryId;
 
-  const DiaryViewForBottomSheet({super.key, required this.scrollController});
+  const DiaryViewForBottomSheet({super.key, required this.scrollController, required this.diaryId});
 
   @override
   State<DiaryViewForBottomSheet> createState() =>

--- a/lib/screens/diary/diary_view_for_bottom_sheet.dart
+++ b/lib/screens/diary/diary_view_for_bottom_sheet.dart
@@ -5,12 +5,10 @@ import 'package:flutter/material.dart';
 import 'package:ego/models/ego_info_model.dart';
 import 'package:ego/screens/diary/diary_container.dart';
 import 'package:ego/screens/diary/diary_edit_screen.dart';
-import 'package:ego/widgets/appbar/stack_app_bar.dart';
 import 'package:ego/screens/diary/today_emotion_container.dart';
 import 'package:ego/theme/color.dart';
 import 'package:ego/widgets/customtoast/custom_toast.dart';
 import 'package:ego/widgets/button/svg_button.dart';
-import 'package:http/http.dart';
 
 import 'diary_view_screen.dart';
 import 'helped_ego_info_container.dart';

--- a/lib/screens/record/calendar/calendar_screen.dart
+++ b/lib/screens/record/calendar/calendar_screen.dart
@@ -16,7 +16,7 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
 
   void _onClickValue(int value) {
     ref.read(selectedValueProvider.notifier).state = value;
-    setState(() {}); // 필요하다면 setState 사용 가능
+    setState(() {});
   }
 
   @override

--- a/lib/screens/record/calendar/calendar_screen.dart
+++ b/lib/screens/record/calendar/calendar_screen.dart
@@ -4,24 +4,32 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class CalendarScreen extends ConsumerWidget {
-  CalendarScreen({super.key});
+class CalendarScreen extends ConsumerStatefulWidget {
+  const CalendarScreen({super.key});
 
-  // 날짜 감지 TODO 날짜를 전달 받는 것이 아니라 일별 Diday객체를 감지할 것임 + 거기서 diaryid로 ValendarBottomSheet에서 일기 원본 조회
-  final selectedDateProvider = StateProvider<DateTime?>((ref) => null);
+  @override
+  ConsumerState<CalendarScreen> createState() => _CalendarScreenState();
+}
 
-  void _onClickDate(WidgetRef ref, DateTime date) {
-    ref.read(selectedDateProvider.notifier).state = date;
+class _CalendarScreenState extends ConsumerState<CalendarScreen> {
+  final selectedValueProvider = StateProvider<int>((ref) => 0);
+
+  void _onClickValue(int value) {
+    ref.read(selectedValueProvider.notifier).state = value;
+    setState(() {}); // 필요하다면 setState 사용 가능
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
+    final selectedValue = ref.watch(selectedValueProvider);
+
     return Stack(
       children: [
         DiaryCalendar(
-          onClickDate: (date) => _onClickDate(ref, date),
+          onClickedValue: _onClickValue,
         ),
-        CalendarBottomSheet(),
+        if (selectedValue != 0)
+          CalendarBottomSheet(diaryId: selectedValue),
       ],
     );
   }

--- a/lib/services/diary/monthly_diary_service.dart
+++ b/lib/services/diary/monthly_diary_service.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'package:ego/models/diary/monthly_diary.dart';
+import 'package:ego/utils/constants.dart';
+
+class MonthlyDiaryService {
+
+  static Future<List<MonthlyDiary>> fetchMonthlyDiaries({
+    required String userId,
+    required int year,
+    required int month,
+  }) async {
+    final uri = Uri.parse(
+      '$baseUrl/calendar/$userId?month=$month&year=$year',
+    );
+
+    final response = await http.get(uri);
+
+    if (response.statusCode == 200) {
+      final jsonString = utf8.decode(response.bodyBytes); // 한글 깨짐 방지
+      final decodedJson = json.decode(jsonString);
+      final List<dynamic> nestedList  = decodedJson['data'];
+
+      final List<MonthlyDiary> diaries = nestedList
+          .expand((inner) => inner as List<dynamic>) // 각 월별 리스트 평탄화
+          .map((json) => MonthlyDiary.fromJson(json))
+          .toList();
+
+      return diaries;
+    } else {
+      throw Exception('다이어리 데이터를 불러오지 못했습니다. 상태 코드: ${response.statusCode}');
+    }
+  }
+}

--- a/lib/widgets/bottomsheet/calendar_bottom_sheet.dart
+++ b/lib/widgets/bottomsheet/calendar_bottom_sheet.dart
@@ -1,8 +1,5 @@
 import 'package:ego/screens/diary/diary_view_for_bottom_sheet.dart';
-import 'package:ego/screens/diary/diary_view_screen.dart';
 import 'package:ego/theme/color.dart';
-import 'package:ego/utils/constants.dart';
-import 'package:ego/widgets/diarycard/diary_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 

--- a/lib/widgets/bottomsheet/calendar_bottom_sheet.dart
+++ b/lib/widgets/bottomsheet/calendar_bottom_sheet.dart
@@ -8,13 +8,24 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 /// 사용자의 일간 일기 카드 리스트가 나타난다.
 /// TODO: 일기 카드에 길이가 적용되지 않는 문제있음. 일단 자체 Padding으로 해결
 class CalendarBottomSheet extends StatefulWidget {
-  const CalendarBottomSheet({super.key});
+  final int diaryId;
+
+  const CalendarBottomSheet({super.key, required this.diaryId});
 
   @override
   State<StatefulWidget> createState() => _CalendarBottomSheetState();
 }
 
 class _CalendarBottomSheetState extends State<CalendarBottomSheet> {
+
+  late int diaryId;
+
+  @override
+  void initState() {
+    super.initState();
+    this.diaryId = widget.diaryId;
+  }
+
   @override
   Widget build(BuildContext context) {
     return DraggableScrollableSheet( /// 스크롤 되는 BottomSheet이다.
@@ -24,7 +35,7 @@ class _CalendarBottomSheetState extends State<CalendarBottomSheet> {
       maxChildSize: 1.0, // 최대 값 설정 (부모 컴포넌트 기준 비율)
       /// BottomSheet에 나타날 컴포넌트
       builder: (BuildContext context, ScrollController scrollController) {
-        return DiaryViewForBottomSheet(scrollController: scrollController);
+        return DiaryViewForBottomSheet(scrollController: scrollController, diaryId: diaryId);
       }
     );
   }


### PR DESCRIPTION
### JIRA Task 🔖
**Ticket**: [CMYK-223](https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-223)
- **Branch** : feature/CMYK-223

### 작업 내용 📌
- 감정 캘린더에서 월별 일기를 보여줍니다.

### 예시 화면 🖥
|실행화면|
|---|
|<img width="300" src="https://github.com/user-attachments/assets/95032472-9532-48b4-9001-59512f2fa8bf" />|

### 작업 배경 🔎 
- 사용자는 캘린더에서 일기를 한눈에 확인할 수 있습니다.

### 참고 사항 📂
- 하단에 띄워지는 일기 내용은 Diary객체, DIaryViewScreen, DiaryEditScreen이 바뀌어야해서 해당 이슈에서 처리하지 않고,
[해당이슈](https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-224)가 처리됨과 동시에 같이 작업 하겠습니다.
- 현재는 일기가 쓰인 날에만 일기 화면을 보이기 + DiaryId 전달 까지 완료 되었습니다.

[CMYK-223]: https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-223