### PR TITLE
[CMYK-253] : Speak화면에 Model 띄우기

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
     <application
         android:label="ego"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/screens/speak_screen.dart
+++ b/lib/screens/speak_screen.dart
@@ -10,7 +10,10 @@ import 'package:ego/widgets/egoicon/ego_list_item_gradient.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:o3d/o3d.dart';
 
+import '../widgets/animation/animation_object_widget.dart';
+import '../widgets/animation/frame_animation.dart';
 import 'egolistview/ego_list_blurred_screen.dart';
 
 class SpeakScreen extends ConsumerStatefulWidget {
@@ -26,10 +29,22 @@ class SpeakScreenState extends ConsumerState<SpeakScreen>
   late final List<EgoModelV2> egoList = [];
   EgoModelV2? selectedEgo;
 
+  late String animation;
+  late bool cameraControls;
+  late bool autoRotate;
+  late bool autoPlay;
+  late List<FrameAnimation> animationsData;
+
   /// _tabCntroller 초기화
   @override
   void initState() {
     super.initState();
+    animation = "";
+    cameraControls = true;
+    autoRotate = false;
+    autoPlay = true;
+    animationsData = FrameAnimationsData;
+
     _fetchChatRoomList();
   }
 
@@ -129,19 +144,15 @@ class SpeakScreenState extends ConsumerState<SpeakScreen>
             ),
 
             // TODO 여기서 EGO가 움직입니다.
-            Expanded(
-              child: Container(
-                color: Colors.green.withOpacity(0.3), // 영역 표시용 배경색
-                child: Center(
-                  child: Container(
-                    child: Image.asset(
-                      'assets/image/ego_1.png',
-                      fit: BoxFit.contain,
-                    ),
-                  ),
-                ),
-              ),
-            ),
+            // E/FrameEvents( 4492): updateAcquireFence: Did not find frame.로 인해 log를 가려서 주석처리 했습니다.
+            // Expanded(
+            //   child: AnimationObjectWidget(
+            //     animationName: animation,
+            //     cameraControls: cameraControls,
+            //     autoRotate: autoRotate,
+            //     autoPlay: autoPlay,
+            //   ),
+            // ),
 
             // selectedEgo는 EgoList를 불러온 이후 할당되는데, 해당 buildSelectedEGO에서
             //null check operator을 수행하는 바람에 순간적으로 null 화면이 보입니다. 때문에 이를 방지하기 위해

--- a/lib/widgets/animation/animation_object_widget.dart
+++ b/lib/widgets/animation/animation_object_widget.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:o3d/o3d.dart';
+
+class AnimationObjectWidget extends StatelessWidget {
+  final String animationName;
+  final bool cameraControls;
+  final bool autoRotate;
+  final bool autoPlay;
+
+  const AnimationObjectWidget({
+    super.key,
+    required this.animationName,
+    this.cameraControls = true,
+    required this.autoRotate,
+    required this.autoPlay,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return O3D(
+      src: 'assets/Ego_model.glb',
+      ar: false,
+      autoPlay: autoPlay,
+      autoRotate: autoRotate,
+      autoRotateDelay: 0,
+      animationName: animationName,
+      cameraControls: cameraControls,
+      cameraOrbit: CameraOrbit(0, 90, 2.0),
+    );
+  }
+}

--- a/lib/widgets/animation/frame_animation.dart
+++ b/lib/widgets/animation/frame_animation.dart
@@ -1,0 +1,15 @@
+class FrameAnimation {
+  String name;
+  String key;// 해당 값이 glb파일에 있는 애니메이션 값과 같아야합니다.
+  bool isChosen;
+
+  FrameAnimation({required this.name, required this.key, required this.isChosen});
+}
+
+// 임시 값들
+List<FrameAnimation> FrameAnimationsData = [
+  FrameAnimation(name: 'SAY-HI', key: 'SAY-HI', isChosen: false),
+  FrameAnimation(name: 'IDK', key: 'IDK', isChosen: false),
+  FrameAnimation(name: 'SURPRISED', key: 'SURPRISED', isChosen: false),
+  FrameAnimation(name: 'THINKING', key: 'THINKING', isChosen: false),
+];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,6 +64,7 @@ dependencies:
   cloud_firestore: ^5.6.7
   firebase_database: ^11.3.5
   smooth_page_indicator: ^1.2.1
+  o3d: ^3.1.0
 
 dependency_overrides:
   intl: ^0.20.2
@@ -185,6 +186,7 @@ flutter:
     - assets/icon/emoji_send_btn.svg
     - assets/icon/trash_enabled.svg
     - assets/icon/error_icon.svg
+    - assets/Ego_model.glb
 
 
 


### PR DESCRIPTION
### JIRA Task 🔖
**Ticket**: [CMYK-253](https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-253)
- **Branch** : feature/CMYK-253

### 작업 내용 📌
- model을 speack화면에 띄웁니다.
- mainfest.xml파일 수정

### 예시 화면 🖥
|실행화면|주석처리후 화면|
|---|---|
|<img width="300" src="https://github.com/user-attachments/assets/6cd94e30-c4aa-4b86-8d94-e64dc8cfd149" />|<img width="300" src="https://github.com/user-attachments/assets/f0c3f083-5f7d-470b-9947-4bf10217867d" />|

### 작업 배경 🔎 

### 참고 사항 📂
- 현재 o3d를 사용하면 "updateAcquireFence: Did not find frame." 로그가 계속 출력되어, 모델이 표시되는 부분을 주석 처리했습니다.
해당 로그는 너무 많은 동작이 한 화면에서 몰아서 처리될 때 출력되는 로그라고 합니다.
성능 저하나 오류를 발생시키지는 않는다고는 하나, 개발 중에 다른 로그를 가릴 수 있을 것 같아 주석 처리했습니다.
(주석을 제거하면 모델은 정상적으로 잘 표시됩니다.)
- 현재 애니메이션 동작 구분은 스튜디오와 상의중이라 전체 애니메이션이 구분 없이 자동 재생됩니다.

[CMYK-253]: https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-253